### PR TITLE
Fix macOS options

### DIFF
--- a/.github/workflows/fastdeploy-builder.yml
+++ b/.github/workflows/fastdeploy-builder.yml
@@ -96,6 +96,13 @@ jobs:
             echo "CXX=cl" >> $GITHUB_ENV
             echo "OpenCV=/lib" >> $GITHUB_ENV
 
+      - name: Patch FastDeploy CMake for macOS
+        if: runner.os == 'macOS'
+        run: |
+            cd ${GITHUB_WORKSPACE}/FastDeploy
+            sed -i'' -e '/-D_GLIBCXX_USE_CXX11_ABI/d' CMakeLists.txt
+            sed -i'' -e '/-D_GLIBCXX_USE_CXX11_ABI/d' FastDeploy.cmake.in
+
       - name: Configure FastDeploy
         run: |
             cd ${GITHUB_WORKSPACE}/FastDeploy
@@ -122,7 +129,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}/FastDeploy/build
             cmake .. \
               -DCMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}" \
-              -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
 
       - name: Build FastDeploy
         run: |


### PR DESCRIPTION
Paddle2ONNX 的 deployment target 是 11.6。为了 SDK 版本匹配，在编译中将 target 设置为 12.0。

GLIBCXX_USE_CXX11_ABI 选项会和 clang 下的 range-v3 起冲突，在这里 patch 掉，这样在 Maa 编译就不用额外处理了。